### PR TITLE
Leaflet 1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "esri-leaflet-react-demo",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "esri-leaflet-react-demo",
-      "version": "0.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
         "esri-leaflet": "^3.0.0",
         "esri-leaflet-vector": "^3.0.0",
-        "leaflet": "^1.7.1",
+        "leaflet": "^1.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -11371,9 +11371,9 @@
       }
     },
     "node_modules/leaflet": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.8.0.tgz",
-      "integrity": "sha512-gwhMjFCQiYs3x/Sf+d49f10ERXaEFCPr+nVTryhAW8DWbMGqJqt9G4XuIaHmFW08zYvhgdzqXGr8AlW8v8dQkA=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.0.tgz",
+      "integrity": "sha512-lL8433PmoPoTSfPoPMzsQdTKmH36Rn2bQx9/j0bbZ98LimrsMof0P+7AQ0LntwRbjXe601j/IY1P2mwBRnN/1Q=="
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -24931,9 +24931,9 @@
       }
     },
     "leaflet": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.8.0.tgz",
-      "integrity": "sha512-gwhMjFCQiYs3x/Sf+d49f10ERXaEFCPr+nVTryhAW8DWbMGqJqt9G4XuIaHmFW08zYvhgdzqXGr8AlW8v8dQkA=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.0.tgz",
+      "integrity": "sha512-lL8433PmoPoTSfPoPMzsQdTKmH36Rn2bQx9/j0bbZ98LimrsMof0P+7AQ0LntwRbjXe601j/IY1P2mwBRnN/1Q=="
     },
     "leven": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "esri-leaflet": "^3.0.0",
         "esri-leaflet-vector": "^3.0.0",
-        "leaflet": "^1.9.0",
+        "leaflet": "^1.9.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -11371,9 +11371,9 @@
       }
     },
     "node_modules/leaflet": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.0.tgz",
-      "integrity": "sha512-lL8433PmoPoTSfPoPMzsQdTKmH36Rn2bQx9/j0bbZ98LimrsMof0P+7AQ0LntwRbjXe601j/IY1P2mwBRnN/1Q=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.2.tgz",
+      "integrity": "sha512-Kc77HQvWO+y9y2oIs3dn5h5sy2kr3j41ewdqCMEUA4N89lgfUUfOBy7wnnHEstDpefiGFObq12FdopGRMx4J7g=="
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -24931,9 +24931,9 @@
       }
     },
     "leaflet": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.0.tgz",
-      "integrity": "sha512-lL8433PmoPoTSfPoPMzsQdTKmH36Rn2bQx9/j0bbZ98LimrsMof0P+7AQ0LntwRbjXe601j/IY1P2mwBRnN/1Q=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.2.tgz",
+      "integrity": "sha512-Kc77HQvWO+y9y2oIs3dn5h5sy2kr3j41ewdqCMEUA4N89lgfUUfOBy7wnnHEstDpefiGFObq12FdopGRMx4J7g=="
     },
     "leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@testing-library/user-event": "^13.5.0",
     "esri-leaflet": "^3.0.0",
     "esri-leaflet-vector": "^3.0.0",
-    "leaflet": "^1.9.0",
+    "leaflet": "^1.9.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@testing-library/user-event": "^13.5.0",
     "esri-leaflet": "^3.0.0",
     "esri-leaflet-vector": "^3.0.0",
-    "leaflet": "^1.7.1",
+    "leaflet": "^1.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",


### PR DESCRIPTION
Updated to Leaflet 1.9. Note that [`v1.9.1` has an issue](https://github.com/Leaflet/Leaflet/issues/8451), but `v1.9.2` works.